### PR TITLE
FAL-2027: Upgrade to 1.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ language: php
 services:
   - mongodb
 
-# Note: latest PHP version is tested with coverage
 php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   global:
@@ -36,7 +37,7 @@ jobs:
   include:
     # Run tests with coverage
     - stage: test
-      php: 7.2
+      php: 7.3
       script:
         - vendor/bin/phpunit --coverage-clover=coverage.clover
       after_script:
@@ -63,7 +64,7 @@ jobs:
 
     - stage: Code Quality
       env: CODING_STANDARDS
-      php: 7.1
+      php: 7.2
       script:
         - ./vendor/bin/phpcs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
     # Test against legacy driver to ensure validity of the test suite
     - stage: Test
       php: 5.6
+      env: DRIVER_VERSION="1.7.5"
       install:
         - yes '' | pecl -q install -f mongo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ php:
 env:
   global:
     - DRIVER_VERSION="stable"
-  matrix:
-    - DRIVER_VERSION="stable"
-    - DRIVER_VERSION="1.3.4"
 
 addons:
   apt:

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,16 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.9 (2019-08-07)
+------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.9](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.9)
+milestone.
+
+ * [#255](https://github.com/alcaeus/mongo-php-adapter/pull/255) fixes inserting
+ documents with identifiers PHP considers empty.
+
 1.1.8 (2019-07-14)
 ------------------
 

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,21 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.6 (2019-02-08)
+------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.6](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.6)
+milestone.
+
+ * [#244](https://github.com/alcaeus/mongo-php-adapter/pull/244) fixes a null
+ acces when converting exceptions.
+ * [#236](https://github.com/alcaeus/mongo-php-adapter/pull/236) allows using
+ `0` as key in documents.
+ * [#234](https://github.com/alcaeus/mongo-php-adapter/pull/234) removes an
+ invalid attribute from phpunit.xml.
+
+
 1.1.5 (2018-03-05)
 -----------------
 

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,17 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.7 (2019-04-06)
+------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.7](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.7)
+milestone.
+
+ * [#250](https://github.com/alcaeus/mongo-php-adapter/pull/250) fixes type
+ conversion when passing write concern to `MongoClient` via URL arguments.
+
+
 1.1.6 (2019-02-08)
 ------------------
 
@@ -11,7 +22,7 @@ All issues and pull requests under this release may be found under the
 milestone.
 
  * [#244](https://github.com/alcaeus/mongo-php-adapter/pull/244) fixes a null
- acces when converting exceptions.
+ access when converting exceptions.
  * [#236](https://github.com/alcaeus/mongo-php-adapter/pull/236) allows using
  `0` as key in documents.
  * [#234](https://github.com/alcaeus/mongo-php-adapter/pull/234) removes an

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,18 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.11 (2019-11-11)
+-------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.11](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.11)
+milestone.
+
+ * [#263](https://github.com/alcaeus/mongo-php-adapter/pull/263) fixes test
+ failures on PHP 7.4.
+ * [#262](https://github.com/alcaeus/mongo-php-adapter/pull/262) fixes a memory
+ leak due to generators that aren't freed.
+
 1.1.10 (2019-11-06)
 -------------------
 

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,16 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.8 (2019-07-14)
+------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.8](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.8)
+milestone.
+
+ * [#253](https://github.com/alcaeus/mongo-php-adapter/pull/253) fixes wrong
+ handling of `ArrayObject` instances in `MongoCollection::insert`.
+
 1.1.7 (2019-04-06)
 ------------------
 

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -3,6 +3,20 @@ CHANGELOG for 1.1.x
 
 This changelog references the relevant changes done in minor version updates.
 
+1.1.10 (2019-11-06)
+-------------------
+
+All issues and pull requests under this release may be found under the
+[1.1.10](https://github.com/alcaeus/mongo-php-adapter/issues?q=milestone%3A1.1.10)
+milestone.
+
+ * [#261](https://github.com/alcaeus/mongo-php-adapter/pull/261) fixes missing
+ interface implementations in cursor classes.
+ * [#260](https://github.com/alcaeus/mongo-php-adapter/pull/260) fixes issues
+ when running against MongoDB 4.2 or `ext-mongodb` 1.6.
+ * [#259](https://github.com/alcaeus/mongo-php-adapter/pull/259) fixes issues on
+ PHP 7.3 due to `MongoCursor` not implementing `Countable`.
+
 1.1.9 (2019-08-07)
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "alcaeus/mongo-php-adapter",
     "type": "library",
-    "description": "Adapter to provide ext-mongo interface on top of mongo-php-libary",
+    "description": "Adapter to provide ext-mongo interface on top of mongo-php-library",
     "keywords": ["mongodb", "database"],
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
+        "ext-ctype": "*",
         "ext-hash": "*",
         "ext-mongodb": "^1.2.0",
         "mongodb/mongodb": "^1.0.1"

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -52,7 +52,7 @@ abstract class AbstractCursor
     protected $db;
 
     /**
-     * @var \Iterator
+     * @var CursorIterator
      */
     protected $iterator;
 
@@ -129,11 +129,6 @@ abstract class AbstractCursor
         if ($collectionName) {
             $this->collection = $connection->selectCollection($dbName, $collectionName)->getCollection();
         }
-    }
-
-    public function __destruct()
-    {
-        $this->iterator = null;
     }
 
     /**
@@ -297,9 +292,8 @@ abstract class AbstractCursor
     protected function ensureIterator()
     {
         if ($this->iterator === null) {
-            // MongoDB\Driver\Cursor needs to be wrapped into a \Generator so that a valid \Iterator with working implementations of
-            // next, current, valid, key and rewind is returned. These methods don't work if we wrap the Cursor inside an \IteratorIterator
             $this->iterator = $this->wrapTraversable($this->ensureCursor());
+            $this->iterator->rewind();
         }
 
         return $this->iterator;
@@ -307,13 +301,11 @@ abstract class AbstractCursor
 
     /**
      * @param \Traversable $traversable
-     * @return \Generator
+     * @return CursorIterator
      */
     protected function wrapTraversable(\Traversable $traversable)
     {
-        foreach ($traversable as $key => $value) {
-            yield $key => $value;
-        }
+        return new CursorIterator($traversable);
     }
 
     /**

--- a/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
+++ b/lib/Alcaeus/MongoDbAdapter/AbstractCursor.php
@@ -131,6 +131,11 @@ abstract class AbstractCursor
         }
     }
 
+    public function __destruct()
+    {
+        $this->iterator = null;
+    }
+
     /**
      * Returns the current element
      * @link http://www.php.net/manual/en/mongocursor.current.php

--- a/lib/Alcaeus/MongoDbAdapter/CursorIterator.php
+++ b/lib/Alcaeus/MongoDbAdapter/CursorIterator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Alcaeus\MongoDbAdapter;
+
+use IteratorIterator;
+use MongoDB\BSON\ObjectID;
+use Traversable;
+
+/**
+ * @internal
+ */
+final class CursorIterator extends IteratorIterator
+{
+    /** @var bool */
+    private $useIdAsKey;
+
+    public function __construct(Traversable $iterator, $useIdAsKey = false)
+    {
+        parent::__construct($iterator);
+
+        $this->useIdAsKey = $useIdAsKey;
+    }
+
+    public function key()
+    {
+        if (!$this->useIdAsKey) {
+            return parent::key();
+        }
+
+        $current = $this->current();
+
+        if (!isset($current->_id) || (is_object($current->_id) && !$current->_id instanceof ObjectID)) {
+            return parent::key();
+        }
+
+        return (string) $current->_id;
+    }
+}

--- a/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
@@ -32,6 +32,12 @@ class ExceptionConverter
      */
     public static function toLegacy(Exception\Exception $e, $fallbackClass = 'MongoException')
     {
+        // Starting with ext-mongodb 1.6.0, errors during bulk write are always wrapped in a BulkWriteException.
+        // If a BulkWriteException wraps another driver exception, use that instead.
+        if ($e instanceof Exception\BulkWriteException && $e->getPrevious() instanceof Exception\Exception) {
+            $e = $e->getPrevious();
+        }
+
         $message = $e->getMessage();
         $code = $e->getCode();
 

--- a/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
@@ -45,7 +45,7 @@ class ExceptionConverter
             case Exception\WriteException::class:
                 $writeResult = $e->getWriteResult();
 
-                if ($writeResult) {
+                if ($writeResult && $writeResult->getWriteErrors() !== []) {
                     $writeError = $writeResult->getWriteErrors()[0];
 
                     $message = $writeError->getMessage();

--- a/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
+++ b/lib/Alcaeus/MongoDbAdapter/ExceptionConverter.php
@@ -16,6 +16,8 @@
 namespace Alcaeus\MongoDbAdapter;
 
 use MongoDB\Driver\Exception;
+use MongoDB\Driver\WriteError;
+use MongoDB\Driver\WriteResult;
 
 /**
  * @internal
@@ -44,12 +46,13 @@ class ExceptionConverter
             case Exception\BulkWriteException::class:
             case Exception\WriteException::class:
                 $writeResult = $e->getWriteResult();
-
-                if ($writeResult && $writeResult->getWriteErrors() !== []) {
+                // attempt to retrieve write error
+                if ($writeResult instanceof WriteResult && is_array($writeResult->getWriteErrors()) && $writeResult->getWriteErrors() !== []) {
                     $writeError = $writeResult->getWriteErrors()[0];
-
-                    $message = $writeError->getMessage();
-                    $code = $writeError->getCode();
+                    if ($writeError instanceof WriteError) {
+                        $message = $writeError->getMessage();
+                        $code = $writeError->getCode();
+                    }
                 }
 
                 switch ($code) {

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -222,7 +222,7 @@ class MongoClient
             $results[$key] = [
                 'host' => $server->getHost(),
                 'port' => $server->getPort(),
-                'health' => (int) $info['ok'],
+                'health' => 1,
                 'state' => $state,
                 'ping' => $server->getLatency(),
                 'lastPing' => null,

--- a/lib/Mongo/MongoClient.php
+++ b/lib/Mongo/MongoClient.php
@@ -376,6 +376,8 @@ class MongoClient
             $keyValue = explode('=', $option);
             if ($keyValue[0] === 'readPreferenceTags') {
                 $options[$keyValue[0]][] = $this->getReadPreferenceTags($keyValue[1]);
+            } elseif (ctype_digit($keyValue[1])) {
+                $options[$keyValue[0]] = (int) $keyValue[1];
             } else {
                 $options[$keyValue[0]] = $keyValue[1];
             }

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -983,7 +983,7 @@ class MongoCollection
     private function checkKeys(array $array)
     {
         foreach ($array as $key => $value) {
-            if (empty($key) && $key !== 0) {
+            if (empty($key) && $key !== 0 && $key !== '0') {
                 throw new \MongoException('zero-length keys are not allowed, did you use $ with double quotes?');
             }
 

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -20,6 +20,7 @@ if (class_exists('MongoCollection', false)) {
 use Alcaeus\MongoDbAdapter\Helper;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;
+use MongoDB\Driver\Exception\CommandException;
 
 /**
  * Represents a database collection.
@@ -626,7 +627,9 @@ class MongoCollection
 
             $this->collection->createIndex($keys, $options);
         } catch (\MongoDB\Driver\Exception\Exception $e) {
-            throw ExceptionConverter::toLegacy($e, 'MongoResultException');
+            if (! $e instanceof CommandException || strpos($e->getMessage(), 'with a different name') === false) {
+                throw ExceptionConverter::toLegacy($e, 'MongoResultException');
+            }
         }
 
         $result = [

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -999,12 +999,12 @@ class MongoCollection
      */
     private function ensureDocumentHasMongoId(&$document)
     {
-        if (is_array($document)) {
+        if (is_array($document) || $document instanceof ArrayObject) {
             if (! isset($document['_id'])) {
                 $document['_id'] = new \MongoId();
             }
 
-            $this->checkKeys($document);
+            $this->checkKeys((array) $document);
 
             return $document['_id'];
         } elseif (is_object($document)) {

--- a/lib/Mongo/MongoCollection.php
+++ b/lib/Mongo/MongoCollection.php
@@ -277,7 +277,7 @@ class MongoCollection
      */
     public function insert(&$a, array $options = [])
     {
-        if (! $this->ensureDocumentHasMongoId($a)) {
+        if ($this->ensureDocumentHasMongoId($a) === null) {
             trigger_error(sprintf('%s(): expects parameter %d to be an array or object, %s given', __METHOD__, 1, gettype($a)), E_USER_WARNING);
             return;
         }

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -28,7 +28,7 @@ use MongoDB\Operation\Find;
  * Result object for database query.
  * @link http://www.php.net/manual/en/class.mongocursor.php
  */
-class MongoCursor extends AbstractCursor implements Iterator
+class MongoCursor extends AbstractCursor implements Iterator, Countable
 {
     /**
      * @var bool

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -18,6 +18,7 @@ if (class_exists('MongoCursor', false)) {
 }
 
 use Alcaeus\MongoDbAdapter\AbstractCursor;
+use Alcaeus\MongoDbAdapter\CursorIterator;
 use Alcaeus\MongoDbAdapter\TypeConverter;
 use Alcaeus\MongoDbAdapter\ExceptionConverter;
 use MongoDB\Driver\Cursor;
@@ -472,16 +473,11 @@ class MongoCursor extends AbstractCursor implements Iterator, Countable, MongoCu
 
     /**
      * @param \Traversable $traversable
-     * @return \Generator
+     * @return CursorIterator
      */
     protected function wrapTraversable(\Traversable $traversable)
     {
-        foreach ($traversable as $key => $value) {
-            if (isset($value->_id) && ($value->_id instanceof \MongoDB\BSON\ObjectID || !is_object($value->_id))) {
-                $key = (string) $value->_id;
-            }
-            yield $key => $value;
-        }
+        return new CursorIterator($traversable, true);
     }
 
     /**

--- a/lib/Mongo/MongoCursor.php
+++ b/lib/Mongo/MongoCursor.php
@@ -28,7 +28,7 @@ use MongoDB\Operation\Find;
  * Result object for database query.
  * @link http://www.php.net/manual/en/class.mongocursor.php
  */
-class MongoCursor extends AbstractCursor implements Iterator, Countable
+class MongoCursor extends AbstractCursor implements Iterator, Countable, MongoCursorInterface
 {
     /**
      * @var bool

--- a/lib/Mongo/MongoDate.php
+++ b/lib/Mongo/MongoDate.php
@@ -88,14 +88,13 @@ class MongoDate implements TypeInterface
     public function toDateTime()
     {
         $datetime = new \DateTime();
+        $datetime->setTimezone(new \DateTimeZone("UTC"));
         $datetime->setTimestamp($this->sec);
 
         $microSeconds = $this->truncateMicroSeconds($this->usec);
         if ($microSeconds > 0) {
-            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u', $datetime->format('Y-m-d H:i:s') . '.' . str_pad($microSeconds, 6, '0', STR_PAD_LEFT));
+            $datetime = \DateTime::createFromFormat('Y-m-d H:i:s.u e', $datetime->format('Y-m-d H:i:s') . '.' . str_pad($microSeconds, 6, '0', STR_PAD_LEFT) . ' UTC');
         }
-
-        $datetime->setTimezone(new \DateTimeZone("UTC"));
 
         return $datetime;
     }

--- a/lib/Mongo/MongoGridFSCursor.php
+++ b/lib/Mongo/MongoGridFSCursor.php
@@ -17,7 +17,7 @@ if (class_exists('MongoGridFSCursor', false)) {
     return;
 }
 
-class MongoGridFSCursor extends MongoCursor
+class MongoGridFSCursor extends MongoCursor implements Countable
 {
     /**
      * @static

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <php>
         <!-- Disable deprecation warnings -->

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -283,7 +283,6 @@ class MongoClientTest extends TestCase
     {
         $client = new \MongoClient('mongodb://localhost/db?w=0&wtimeout=0', ['connect' => false]);
 
-        $this->skipTestIf(extension_loaded('mongo'));
         $this->assertSame(['w' => 0, 'wtimeout' => 0], $client->getWriteConcern());
     }
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoClientTest.php
@@ -279,6 +279,14 @@ class MongoClientTest extends TestCase
         $collection->insert($document);
     }
 
+    public function testConnectionUriOptionIntegerTypeCasting()
+    {
+        $client = new \MongoClient('mongodb://localhost/db?w=0&wtimeout=0', ['connect' => false]);
+
+        $this->skipTestIf(extension_loaded('mongo'));
+        $this->assertSame(['w' => 0, 'wtimeout' => 0], $client->getWriteConcern());
+    }
+
     /**
      * @param array $options
      * @return string

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -130,6 +130,20 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCollection()->count(['foo']));
     }
 
+    public function testInsertWithAlphaNumbericKey()
+    {
+        /**
+         * Force the array to store the key as a string "0".
+         * Initialising like ['0' => 'foo'] casts the string to an int.
+         */
+        $document = new \stdClass();
+        $document->{'0'} = 'foo';
+        $document = (array) $document;
+
+        $this->getCollection()->insert($document);
+        $this->assertSame(1, $this->getCollection()->count(['0' => 'foo']));
+    }
+
     public function testInsertDuplicate()
     {
         $collection = $this->getCollection();

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -2,9 +2,11 @@
 
 namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
+use ArrayObject;
 use MongoDB\BSON\Regex;
 use MongoDB\Driver\ReadPreference;
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
+use MongoId;
 use PHPUnit\Framework\Error\Warning;
 
 /**
@@ -93,6 +95,15 @@ class MongoCollectionTest extends TestCase
 
         $document = new PrivatePropertiesStub();
         $this->getCollection()->insert($document);
+    }
+
+    public function testInsertArrayObjectWithProtectedProperties()
+    {
+        $document = new ArrayObjectWithProtectedProperties(['foo' => 'bar']);
+        $this->getCollection()->insert($document);
+
+        $this->assertInstanceOf('MongoId', $document['_id']);
+        $this->assertEquals(['_id' => $document['_id'], 'foo' => 'bar'], $this->getCollection()->findOne(['_id' => $document['_id']]));
     }
 
     public function testInsertWithInvalidKey()
@@ -1990,4 +2001,9 @@ class MongoCollectionTest extends TestCase
 class PrivatePropertiesStub
 {
     private $foo = 'bar';
+}
+
+class ArrayObjectWithProtectedProperties extends ArrayObject
+{
+    protected $something = 'baz';
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -47,10 +47,10 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $object);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $object->_id);
         $this->assertSame($id, (string) $object->_id);
-        $this->assertObjectHasAttribute('foo', $object);
-        $this->assertAttributeSame('bar', 'foo', $object);
+        $this->assertNotNull($object->foo);
+        $this->assertSame('bar', $object->foo);
     }
 
     public function testInsertInvalidData()
@@ -1072,10 +1072,9 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $object);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $object->_id);
         $this->assertSame($id, (string) $object->_id);
-        $this->assertObjectHasAttribute('foo', $object);
-        $this->assertAttributeSame('bar', 'foo', $object);
+        $this->assertSame('bar', $object->foo);
     }
 
     public function testRemoveOne()
@@ -1115,10 +1114,9 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $object);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $object->_id);
         $this->assertSame($id, (string) $object->_id);
-        $this->assertObjectHasAttribute('foo', $object);
-        $this->assertAttributeSame('foo', 'foo', $object);
+        $this->assertSame('foo', $object->foo);
     }
 
     public function testSavingShouldReplaceTheWholeDocument()
@@ -1137,7 +1135,7 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertObjectNotHasAttribute('foo', $object);
+        $this->assertArrayNotHasKey('bar', $object);
     }
 
     public function testSaveDuplicate()
@@ -1612,7 +1610,7 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeSame('foo', 'foo', $object);
+        $this->assertSame('foo', $object->foo);
     }
 
     public function testFindAndModifyUpdateWithUpdateOptions()
@@ -1637,8 +1635,8 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeSame('foo', 'bar', $object);
-        $this->assertObjectNotHasAttribute('foo', $object);
+        $this->assertSame('foo', $object->bar);
+        $this->assertArrayNotHasKey('foo', $object);
     }
 
     public function testFindAndModifyWithUpdateParamAndOption()
@@ -1666,8 +1664,8 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeSame('foobar', 'foo', $object);
-        $this->assertObjectNotHasAttribute('bar', $object);
+        $this->assertSame('foobar', $object->foo);
+        $this->assertArrayNotHasKey('bar', $object);
     }
 
     public function testFindAndModifyUpdateReplace()
@@ -1688,8 +1686,8 @@ class MongoCollectionTest extends TestCase
         $object = $newCollection->findOne();
 
         $this->assertNotNull($object);
-        $this->assertAttributeSame('boo', 'foo', $object);
-        $this->assertObjectNotHasAttribute('bar', $object);
+        $this->assertSame('boo', $object->foo);
+        $this->assertArrayNotHasKey('bar', $object);
     }
 
     public function testFindAndModifyUpdateReturnNew()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1912,7 +1912,7 @@ class MongoCollectionTest extends TestCase
             'nIndexesWas' => 1,
             'ok' => 1.0
         ];
-        $this->assertSame($expected, $this->getCollection()->drop());
+        $this->assertEquals($expected, $this->getCollection()->drop());
     }
 
     public function testEmptyCollectionName()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1896,7 +1896,6 @@ class MongoCollectionTest extends TestCase
                 'ns' => 'mongo-php-adapter.test',
                 'nrecords' => 1,
                 'nIndexes' => 1,
-                'keysPerIndex' => ['mongo-php-adapter.test.$_id_' => 1],
                 'valid' => true,
                 'errors' => [],
             ],

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -130,7 +130,7 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCollection()->count(['foo']));
     }
 
-    public function testInsertWithAlphaNumbericKey()
+    public function testInsertWithAlphaNumericKey()
     {
         /**
          * Force the array to store the key as a string "0".

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -1730,6 +1730,8 @@ class MongoCollectionTest extends TestCase
 
     public function testGroup()
     {
+        $this->skipTestIf(version_compare($this->getServerVersion(), '4.2.0', '>='), 'Test does not apply to MongoDB >= 4.2.');
+
         $collection = $this->getCollection();
 
         $document1 = ['a' => 2];

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -80,6 +80,34 @@ class MongoCollectionTest extends TestCase
         $this->assertSame(1, $this->getCollection()->count(['_id' => $document['_id']]));
     }
 
+    /**
+     * @dataProvider emptyIdProvider
+     */
+    public function testInsertArrayWithEmptyIds($id)
+    {
+        $document = ['_id' => $id];
+        $this->getCollection()->insert($document);
+
+        $this->assertSame(1, $this->getCollection()->count(['_id' => $id]));
+    }
+
+    public function emptyIdProvider()
+    {
+        return [
+            'Zero as string' => ['0'],
+            'Zero as int' => [0],
+            'Empty string' => [''],
+        ];
+    }
+
+    public function testInsertArrayWithEmptyId()
+    {
+        $document = ['_id' => ''];
+        $this->getCollection()->insert($document);
+
+        $this->assertSame(1, $this->getCollection()->count(['_id' => $document['_id']]));
+    }
+
     public function testInsertEmptyObject()
     {
         $document = (object) [];

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCollectionTest.php
@@ -8,6 +8,7 @@ use MongoDB\Driver\ReadPreference;
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
 use MongoId;
 use PHPUnit\Framework\Error\Warning;
+use function extension_loaded;
 
 /**
  * @author alcaeus <alcaeus@alcaeus.org>
@@ -844,6 +845,8 @@ class MongoCollectionTest extends TestCase
 
     public function testAggregate()
     {
+        $this->skipTestIf(extension_loaded('mongo'));
+
         $collection = $this->getCollection();
 
         $this->prepareData();
@@ -860,7 +863,7 @@ class MongoCollectionTest extends TestCase
             ]
         ];
 
-        $result = $collection->aggregate($pipeline);
+        $result = $collection->aggregate($pipeline, ['cursor' => true]);
         $this->assertInternalType('array', $result);
         $this->assertArrayHasKey('result', $result);
 
@@ -872,6 +875,8 @@ class MongoCollectionTest extends TestCase
 
     public function testAggregateWithMultiplePilelineOperatorsAsArguments()
     {
+        $this->skipTestIf(version_compare($this->getServerVersion(), '3.6.0', '>='), 'Test does not apply to MongoDB >= 3.6.');
+
         $collection = $this->getCollection();
 
         $this->prepareData();
@@ -906,6 +911,8 @@ class MongoCollectionTest extends TestCase
 
     public function testAggregateInvalidPipeline()
     {
+        $this->skipTestIf(extension_loaded('mongo'));
+
         $collection = $this->getCollection();
 
         $pipeline = [
@@ -916,7 +923,7 @@ class MongoCollectionTest extends TestCase
 
         $this->expectException(\MongoResultException::class);
         $this->expectExceptionMessage('Unrecognized pipeline stage name');
-        $collection->aggregate($pipeline);
+        $collection->aggregate($pipeline, ['cursor' => true]);
     }
 
     public function testAggregateTimeoutException()
@@ -939,7 +946,7 @@ class MongoCollectionTest extends TestCase
             ]
         ];
 
-        $collection->aggregate($pipeline, ['maxTimeMS' => 1]);
+        $collection->aggregate($pipeline, ['maxTimeMS' => 1, 'cursor' => true]);
     }
 
     public function testAggregateCursor()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCommandCursorTest.php
@@ -2,6 +2,7 @@
 
 namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
+use MongoCursorInterface;
 use MongoDB\Database;
 use MongoDB\Driver\ReadPreference;
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
@@ -201,5 +202,13 @@ class MongoCommandCursorTest extends TestCase
                 ReadPreference::RP_SECONDARY,
             ],
         ];
+    }
+
+    public function testInterfaces()
+    {
+        $this->prepareData();
+        $cursor = $this->getCollection()->aggregateCursor([['$match' => ['foo' => 'bar']]]);
+
+        $this->assertInstanceOf(MongoCursorInterface::class, $cursor);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoCursorTest.php
@@ -4,6 +4,8 @@ namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
 use Alcaeus\MongoDbAdapter\TypeConverter;
+use Countable;
+use MongoCursorInterface;
 use MongoDB\Driver\ReadPreference;
 use MongoDB\Model\BSONDocument;
 use MongoDB\Operation\Find;
@@ -514,6 +516,19 @@ class MongoCursorTest extends TestCase
         ];
 
         $this->assertArraySubset($expected, $cursor->explain());
+    }
+
+    public function testInterfaces()
+    {
+        $collection = $this->getCollection();
+        $cursor = $collection->find();
+
+        $this->assertInstanceOf(MongoCursorInterface::class, $cursor);
+
+        // The countable interface is necessary for compatibility with PHP 7.3+, but not implemented by MongoCursor
+        if (! extension_loaded('mongo')) {
+            $this->assertInstanceOf(Countable::class, $cursor);
+        }
     }
 
 

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
@@ -240,6 +240,8 @@ class MongoDBTest extends TestCase
 
     public function testExecute()
     {
+        $this->skipTestIf(version_compare($this->getServerVersion(), '4.2.0', '>='), 'Eval no longer works on MongoDB 4.2.0 and newer');
+
         $db = $this->getDatabase();
         $document = ['foo' => 'bar'];
         $this->getCollection()->insert($document);
@@ -384,11 +386,13 @@ class MongoDBTest extends TestCase
             'nIndexesWas' => 1,
             'ok' => 1.0
         ];
-        $this->assertSame($expected, $this->getDatabase()->dropCollection('test'));
+        $this->assertEquals($expected, $this->getDatabase()->dropCollection('test'));
     }
 
     public function testRepair()
     {
+        $this->skipTestIf(version_compare($this->getServerVersion(), '4.2.0', '>='), 'The "repairDatabase" has been removed in MongoDB 4.2.0');
+
         $this->assertSame(['ok' => 1.0], $this->getDatabase()->repair());
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDBTest.php
@@ -290,7 +290,7 @@ class MongoDBTest extends TestCase
                         ],
                     ];
                 }
-                $this->assertEquals($expected, $collectionInfo);
+                $this->assertArraySubset($expected, $collectionInfo);
                 return;
             }
         }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoDateTest.php
@@ -95,4 +95,33 @@ class MongoDateTest extends TestCase
         $this->assertSame(1234567890, $dateTime->getTimestamp());
         $this->assertSame('012000', $dateTime->format('u'));
     }
+
+    public function testDSTTransitionDoesNotProduceWrongResults()
+    {
+        $initialTZ = ini_get("date.timezone");
+
+        ini_set("date.timezone", "Europe/Madrid");
+
+        $date = new \MongoDate(1603584000);
+        $dateTime = $date->toDateTime();
+
+        $this->assertSame(1603584000, $dateTime->getTimestamp());
+
+        ini_set("date.timezone", $initialTZ);
+    }
+
+    public function testDSTTransitionDoesNotProduceWrongResultsWithMicroSeconds()
+    {
+        $initialTZ = ini_get("date.timezone");
+
+        ini_set("date.timezone", "Europe/Madrid");
+
+        $date = new \MongoDate(1603584000, 123456);
+        $dateTime = $date->toDateTime();
+
+        $this->assertSame(1603584000, $dateTime->getTimestamp());
+        $this->assertSame('123000', $dateTime->format('u'));
+
+        ini_set("date.timezone", $initialTZ);
+    }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSCursorTest.php
@@ -3,6 +3,7 @@
 namespace Alcaeus\MongoDbAdapter\Tests\Mongo;
 
 use Alcaeus\MongoDbAdapter\Tests\TestCase;
+use Countable;
 
 class MongoGridFSCursorTest extends TestCase
 {
@@ -36,5 +37,17 @@ class MongoGridFSCursorTest extends TestCase
                 'md5' => 'acbd18db4cc2f85cedef654fccc4a4d8'
             ], $value->file);
         }
+    }
+
+    public function testInterfaces()
+    {
+        $this->skipTestIf(extension_loaded('mongo'));
+
+        $gridfs = $this->getGridFS();
+        $id = $gridfs->storeBytes('foo', ['filename' => 'foo.txt']);
+        $gridfs->storeBytes('bar', ['filename' => 'bar.txt']);
+
+        $cursor = $gridfs->find(['filename' => 'foo.txt']);
+        $this->assertInstanceOf(Countable::class, $cursor);
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoGridFSTest.php
@@ -70,33 +70,29 @@ class MongoGridFSTest extends TestCase
 
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $record);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $record->_id);
         $this->assertSame((string) $id, (string) $record->_id);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
-        $this->assertObjectHasAttribute('length', $record);
-        $this->assertAttributeSame(4, 'length', $record);
-        $this->assertObjectHasAttribute('chunkSize', $record);
-        $this->assertAttributeSame(2, 'chunkSize', $record);
-        $this->assertObjectHasAttribute('md5', $record);
-        $this->assertAttributeSame('e2fc714c4727ee9395f324cd2e7f331f', 'md5', $record);
+        $this->assertSame('bar', $record->foo);
+        $this->assertSame(4, $record->length);
+        $this->assertSame(2, $record->chunkSize);
+        $this->assertSame('e2fc714c4727ee9395f324cd2e7f331f', $record->md5);
 
         $chunksCursor = $newChunksCollection->find([], ['sort' => ['n' => 1]]);
         $chunks = iterator_to_array($chunksCursor);
         $firstChunk = $chunks[0];
         $this->assertNotNull($firstChunk);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', 'files_id', $firstChunk);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $firstChunk->files_id);
         $this->assertSame((string) $id, (string) $firstChunk->files_id);
-        $this->assertAttributeSame(0, 'n', $firstChunk);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\Binary', 'data', $firstChunk);
+        $this->assertSame(0, $firstChunk->n);
+        $this->assertInstanceOf('MongoDB\BSON\Binary', $firstChunk->data);
         $this->assertSame('ab', (string) $firstChunk->data->getData());
 
         $secondChunck = $chunks[1];
         $this->assertNotNull($secondChunck);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', 'files_id', $secondChunck);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $secondChunck->files_id);
         $this->assertSame((string) $id, (string) $secondChunck->files_id);
-        $this->assertAttributeSame(1, 'n', $secondChunck);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\Binary', 'data', $secondChunck);
+        $this->assertSame(1, $secondChunck->n);
+        $this->assertInstanceOf('MongoDB\BSON\Binary', $secondChunck->data);
         $this->assertSame('cd', (string) $secondChunck->data->getData());
     }
 
@@ -164,18 +160,13 @@ class MongoGridFSTest extends TestCase
         $size = filesize($filename);
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $record);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $record->_id);
         $this->assertSame((string) $id, (string) $record->_id);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
-        $this->assertObjectHasAttribute('length', $record);
-        $this->assertAttributeSame($size, 'length', $record);
-        $this->assertObjectHasAttribute('chunkSize', $record);
-        $this->assertAttributeSame(100, 'chunkSize', $record);
-        $this->assertObjectHasAttribute('md5', $record);
-        $this->assertAttributeSame($md5, 'md5', $record);
-        $this->assertObjectHasAttribute('filename', $record);
-        $this->assertAttributeSame($filename, 'filename', $record);
+        $this->assertSame('bar', $record->foo);
+        $this->assertSame($size, $record->length);
+        $this->assertSame(100, $record->chunkSize);
+        $this->assertSame($md5, $record->md5);
+        $this->assertSame($filename, $record->filename);
 
         $numberOfChunks = (int) ceil($size / 100);
         $this->assertSame($numberOfChunks, $newChunksCollection->count());
@@ -183,10 +174,10 @@ class MongoGridFSTest extends TestCase
 
         $firstChunk = $newChunksCollection->findOne([], ['sort' => ['n' => 1]]);
         $this->assertNotNull($firstChunk);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', 'files_id', $firstChunk);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $firstChunk->files_id);
         $this->assertSame((string) $id, (string) $firstChunk->files_id);
-        $this->assertAttributeSame(0, 'n', $firstChunk);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\Binary', 'data', $firstChunk);
+        $this->assertSame(0, $firstChunk->n);
+        $this->assertInstanceOf('MongoDB\BSON\Binary', $firstChunk->data);
         $this->assertSame($expectedContent, (string) $firstChunk->data->getData());
     }
 
@@ -209,18 +200,13 @@ class MongoGridFSTest extends TestCase
         $filename = basename(__FILE__);
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $record);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $record->_id);
         $this->assertSame((string) $id, (string) $record->_id);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
-        $this->assertObjectHasAttribute('length', $record);
-        $this->assertAttributeSame($size, 'length', $record);
-        $this->assertObjectHasAttribute('chunkSize', $record);
-        $this->assertAttributeSame(100, 'chunkSize', $record);
-        $this->assertObjectHasAttribute('md5', $record);
-        $this->assertAttributeSame($md5, 'md5', $record);
-        $this->assertObjectHasAttribute('filename', $record);
-        $this->assertAttributeSame('test.php', 'filename', $record);
+        $this->assertSame('bar', $record->foo);
+        $this->assertSame($size, $record->length);
+        $this->assertSame(100, $record->chunkSize);
+        $this->assertSame($md5, $record->md5);
+        $this->assertSame('test.php', $record->filename);
 
         $numberOfChunks = (int) ceil($size / 100);
         $this->assertSame($numberOfChunks, $newChunksCollection->count());
@@ -228,10 +214,10 @@ class MongoGridFSTest extends TestCase
 
         $firstChunk = $newChunksCollection->findOne([], ['sort' => ['n' => 1]]);
         $this->assertNotNull($firstChunk);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', 'files_id', $firstChunk);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $firstChunk->files_id);
         $this->assertSame((string) $id, (string) $firstChunk->files_id);
-        $this->assertAttributeSame(0, 'n', $firstChunk);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\Binary', 'data', $firstChunk);
+        $this->assertSame(0, $firstChunk->n);
+        $this->assertInstanceOf('MongoDB\BSON\Binary', $firstChunk->data);
         $this->assertSame($expectedContent, (string) $firstChunk->data->getData());
     }
 
@@ -260,18 +246,13 @@ class MongoGridFSTest extends TestCase
         $size = filesize(__FILE__);
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertAttributeInstanceOf('MongoDB\BSON\ObjectID', '_id', $record);
+        $this->assertInstanceOf('MongoDB\BSON\ObjectID', $record->_id);
         $this->assertSame((string) $id, (string) $record->_id);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
-        $this->assertObjectHasAttribute('length', $record);
-        $this->assertAttributeSame($size, 'length', $record);
-        $this->assertObjectHasAttribute('chunkSize', $record);
-        $this->assertAttributeSame(100, 'chunkSize', $record);
-        $this->assertObjectHasAttribute('md5', $record);
-        $this->assertAttributeSame($md5, 'md5', $record);
-        $this->assertObjectHasAttribute('filename', $record);
-        $this->assertAttributeSame('test.php', 'filename', $record);
+        $this->assertSame('bar', $record->foo);
+        $this->assertSame($size, $record->length);
+        $this->assertSame(100, $record->chunkSize);
+        $this->assertSame($md5, $record->md5);
+        $this->assertSame('test.php', $record->filename);
 
         $numberOfChunks = (int) ceil($size / 100);
         $this->assertSame($numberOfChunks, $newChunksCollection->count());

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoInsertBatchTest.php
@@ -30,8 +30,7 @@ class MongoInsertBatchTest extends TestCase
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
+        $this->assertSame('bar', $record->foo);
     }
 
     public function testInsertBatchWithoutAck()
@@ -52,8 +51,7 @@ class MongoInsertBatchTest extends TestCase
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
+        $this->assertSame('bar', $record->foo);
     }
 
     public function testInsertBatchError()

--- a/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
+++ b/tests/Alcaeus/MongoDbAdapter/Mongo/MongoUpdateBatchTest.php
@@ -35,8 +35,7 @@ class MongoUpdateBatchTest extends TestCase
         $this->assertSame(1, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('foo', 'foo', $record);
+        $this->assertSame('foo', $record->foo);
     }
 
     public function testUpdateOneException()
@@ -100,8 +99,7 @@ class MongoUpdateBatchTest extends TestCase
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('foo', 'foo', $record);
+        $this->assertSame('foo', $record->foo);
     }
 
     public function testUpdateManyWithoutAck()
@@ -129,8 +127,7 @@ class MongoUpdateBatchTest extends TestCase
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('foo', 'foo', $record);
+        $this->assertSame('foo', $record->foo);
     }
 
     public function testUpdateManyException()
@@ -200,8 +197,7 @@ class MongoUpdateBatchTest extends TestCase
         $this->assertSame(2, $newCollection->count());
         $record = $newCollection->findOne();
         $this->assertNotNull($record);
-        $this->assertObjectHasAttribute('foo', $record);
-        $this->assertAttributeSame('bar', 'foo', $record);
+        $this->assertSame('bar', $record->foo);
     }
 
     public function testValidateItem()

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -184,7 +184,11 @@ abstract class TestCase extends BaseTestCase
     protected function getFeatureCompatibilityVersion()
     {
         $featureCompatibilityVersion = $this->getClient()->selectDB('admin')->command(['getParameter' => true, 'featureCompatibilityVersion' => true]);
-        return isset($featureCompatibilityVersion['featureCompatibilityVersion']) ? $featureCompatibilityVersion['featureCompatibilityVersion'] : '3.2';
+        if (! isset($featureCompatibilityVersion['featureCompatibilityVersion'])) {
+            return '3.2';
+        }
+
+        return isset($featureCompatibilityVersion['featureCompatibilityVersion']['version']) ? $featureCompatibilityVersion['featureCompatibilityVersion']['version'] : $featureCompatibilityVersion['featureCompatibilityVersion'];
     }
 
     /**
@@ -200,6 +204,6 @@ abstract class TestCase extends BaseTestCase
 
         // Check featureCompatibilityFlag
         $compatibilityVersion = $this->getFeatureCompatibilityVersion();
-        return $compatibilityVersion === '3.4' ? self::INDEX_VERSION_2 : self::INDEX_VERSION_1;
+        return version_compare($compatibilityVersion, '3.4', '>=') ? self::INDEX_VERSION_2 : self::INDEX_VERSION_1;
     }
 }

--- a/tests/Alcaeus/MongoDbAdapter/TestCase.php
+++ b/tests/Alcaeus/MongoDbAdapter/TestCase.php
@@ -153,18 +153,19 @@ abstract class TestCase extends BaseTestCase
     /**
      * @param bool $condition
      */
-    protected function skipTestUnless($condition)
+    protected function skipTestUnless($condition, $message = null)
     {
-        $this->skipTestIf(! $condition);
+        $this->skipTestIf(! $condition, $message);
     }
 
     /**
      * @param bool $condition
+     * @param string|null $message
      */
-    protected function skipTestIf($condition)
+    protected function skipTestIf($condition, $message = null)
     {
         if ($condition) {
-            $this->markTestSkipped('Test only applies when running against mongo-php-adapter');
+            $this->markTestSkipped($message !== null ? $message : 'Test only applies when running against mongo-php-adapter');
         }
     }
 


### PR DESCRIPTION
This brings us up-to-date with v1.1 of the adapter, which resolves https://github.com/alcaeus/mongo-php-adapter/pull/244 and may resolve other adapter-related bugs as well.

https://maxwellhealth.atlassian.net/browse/FAL-2027